### PR TITLE
Add gmp to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
           numactl
           protobuf
           openal
+          gmp
         ];
       };
     };


### PR DESCRIPTION
Without this a few libraries fail to build with

```
Failed to build glib-0.13.8.2 (which is required by clc-stackage-0.1.0.0). The
failure occurred during the configure step. The exception was:
dieVerbatim: user error (cabal: '/home/ollie/work/ghc/_build/stage1/bin/ghc'
exited with an error:
/nix/store/2b99rpx8zwdjjqkrvk7kqgn9mxhiidjy-binutils-2.38/bin/ld: cannot find
-lgmp: No such file or directory
```