### PR TITLE
Update nixpkgs, ghc.nix url

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "all-cabal-hashes": {
       "flake": false,
       "locked": {
-        "lastModified": 1696116924,
-        "narHash": "sha256-c6R3PkzqDCeAIqB+aygnjIMOmnkAmepyakOqtb8oQrg=",
+        "lastModified": 1713533780,
+        "narHash": "sha256-n3uL80tY7CxDpf+vKlLcwoEmGSx1q3x29CfAowoxSoI=",
         "owner": "commercialhaskell",
         "repo": "all-cabal-hashes",
-        "rev": "bd2d976d126b7730d82c772a207cf34e927aa69d",
+        "rev": "9ccd145a05dbb8880fc87dadaa336831b67002b3",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -76,11 +76,11 @@
       },
       "locked": {
         "host": "gitlab.haskell.org",
-        "lastModified": 1695834759,
-        "narHash": "sha256-VwlqAhx5zv/i7Z8jSoHbdHV7xj6OlIVhCz8X8pxjF8M=",
+        "lastModified": 1713474460,
+        "narHash": "sha256-L3k9NUR9imLfm9EKytXJ9Lsx1AIjjAUgvdYCM0VX/4o=",
         "owner": "ghc",
         "repo": "ghc-wasm-meta",
-        "rev": "bd1b3778e8100a5e8c89962903a8c2ae3ff5c611",
+        "rev": "fe968d0d39f49cae165da757e48d1365c607a38b",
         "type": "gitlab"
       },
       "original": {
@@ -101,17 +101,17 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1696669255,
-        "narHash": "sha256-7fa7La801/aRigO7G+8Rz98RbtpsrGBIGfAD/DLZ5BU=",
-        "owner": "alpmestan",
-        "repo": "ghc.nix",
-        "rev": "c31bcab7a74569e6bd37dbe7de94c97cad1e35e1",
-        "type": "github"
+        "lastModified": 1718307282,
+        "narHash": "sha256-qsnwu7NOufI8rqBwS8Rxl75HRvQ8sWq9aayQd1z/fuQ=",
+        "ref": "refs/heads/main",
+        "rev": "40fd1d7f6513437f796342989cd291e45067b116",
+        "revCount": 282,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc.nix.git"
       },
       "original": {
-        "owner": "alpmestan",
-        "repo": "ghc.nix",
-        "type": "github"
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc.nix.git"
       }
     },
     "gitignore": {
@@ -123,11 +123,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660459072,
-        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
         "type": "github"
       },
       "original": {
@@ -138,43 +138,43 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694343207,
-        "narHash": "sha256-jWi7OwFxU5Owi4k2JmiL1sa/OuBCQtpaAesuj5LXC8w=",
+        "lastModified": 1713248628,
+        "narHash": "sha256-NLznXB5AOnniUtZsyy/aPWOk8ussTuePp2acb9U+ISA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "78058d810644f5ed276804ce7ea9e82d92bee293",
+        "rev": "5672bc9dbf9d88246ddab5ac454e82318d094bb8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1695825837,
-        "narHash": "sha256-4Ne11kNRnQsmSJCRSSNkFRSnHC4Y5gPDBIQGjjPfJiU=",
+        "lastModified": 1713344939,
+        "narHash": "sha256-jpHkAt0sG2/J7ueKnG7VvLLkBYUMQbXQ2L8OBpVG53s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5cfafa12d57374f48bcc36fda3274ada276cf69e",
+        "rev": "e402c3eb6d88384ca6c52ef1c53e61bdc9b84ddd",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_new": {
       "locked": {
-        "lastModified": 1711333969,
-        "narHash": "sha256-5PiWGn10DQjMZee5NXzeA6ccsv60iLu+Xtw+mfvkUAs=",
+        "lastModified": 1725103162,
+        "narHash": "sha256-Ym04C5+qovuQDYL/rKWSR+WESseQBbNAe5DsXNx5trY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "57e6b3a9e4ebec5aa121188301f04a6b8c354c9b",
+        "rev": "12228ff1752d7b7624a54e9c1af4b222b3c1073b",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695576016,
-        "narHash": "sha256-71KxwRhTfVuh7kNrg3/edNjYVg9DCyKZl2QIKbhRggg=",
+        "lastModified": 1712897695,
+        "narHash": "sha256-nMirxrGteNAl9sWiOhoN5tIHyjBbVi5e2tgZUgZlK3Y=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "cb770e93516a1609652fa8e945a0f310e98f10c0",
+        "rev": "40e6053ecb65fcbf12863338a6dcefb3f55f1bf8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,21 +19,13 @@
     # Note this means that this input should generally be upgraded whenever
     # ghc.nix is.
     ghc_nix = {
-      url = "github:alpmestan/ghc.nix";
+      url = "git+https://gitlab.haskell.org/ghc/ghc.nix.git";
       inputs.flake-compat.follows = "flake-compat";
     };
     nixpkgs.follows = "ghc_nix/nixpkgs";
 
-    # We use a newer version of nixpkgs for cabal-install, to avoid
-    # the warning:
-    #
-    #     Warning: Unknown/unsupported 'ghc' version detected (Cabal 3.10.1.0 supports
-    #     'ghc' version < 9.8)
-    #
-    # nixpkgs_new has cabal-install 3.10.2.1, which removes this warning.
-    #
-    # When ghc.nix's nixpkgs has this newer cabal, we can get rid of
-    # nixpkgs_new and use nixpkgs for everything.
+    # Temporarily include a newer version of nixpkgs so that we get the newer
+    # cabal-install 3.12 and can use jsem.
     nixpkgs_new.url = "github:nixos/nixpkgs/nixos-unstable";
   };
 
@@ -43,16 +35,14 @@
       pkgs = import nixpkgs {
         inherit system;
       };
-      pkgs_new = import nixpkgs_new { inherit system; };
+      pkgs_new = import nixpkgs_new {
+        inherit system;
+      };
       compiler = pkgs_new.haskell.packages.ghc982;
 
       # There are some packages that do not build well with nix:
       #
       # - grisette: Depends on sbv
-      #
-      # - hw-json-simd:
-      #   - https://github.com/haskell-works/hw-json-simd/issues/90
-      #   - https://github.com/haskell/core-libraries-committee/issues/158#issuecomment-1537226472
       #
       # - sbv: Builds with the nix-provided GHC in the .#with-ghc shell, but
       #        fails with a custom built GHC (e.g. building via ghc.nix).
@@ -66,10 +56,8 @@
         blas # blas-ffi
         bzip2 # bnb-staking-csvs
         expat # cairo-image
-        fftw # emd
         lapack # lapack-ffi
         libGL # GLUT, etc.
-        openssl # core-telemetry, cql-io
         pcre # regex-pcre
         xorg.libX11 # GLFW-b
         xorg.libXcursor # GLFW-b
@@ -83,35 +71,24 @@
       # The comments indicate haskell packages that require the given
       # dependency. This is not exhaustive.
       deps = with pkgs; [
-        alsa-lib # synthesizer-alsa
         pkgs_new.cabal-install
-        clp # coinor-clp
         curl # curl
-        file # magic requires libmagic
         fribidi # simple-pango
-        glib # alsa-seq
-        glpk # comfort-glpk
-        icu # text-icu
-        jack2 # jack
         libdatrie # simple-pango
         libGLU # GLURaw
         libselinux # simple-pango
         libsepol # simple-pango
-        libsodium # ihaskell
         libthai # simple-pango
         libxml2 # c14n
-        mpfr # hmpfr
         nettle # nettle
         openal # OpenAL
         pango # simple-pango
         pcre2 # simple-cairo
         pkg-config
-        primecount # primecount
         systemdMinimal # hidapi requires udev
         util-linux # simple-pango requires mount
         xorg.libXdmcp # simple-cairo
         xz # lzma
-        zeromq # zeromq4-haskell
       ] ++ ldDeps;
     in
     {


### PR DESCRIPTION
I updated nix to reference the new `ghc.nix` home. I also removed some system packages that are no longer needed, based on the recent removals. I went through and built everything myself, so it should be right.

---

Also, a while back I mentioned I wrote an exe that builds N packages at a time, as opposed to all ~3000. I needed this to circumvent a nix issue, though it could be useful for other reasons (e.g. low memory, better save/restart). The idea is, the exe splits the entire package set from the cabal file into groups of size N, then builds each group sequentially. It can be interrupted (e.g. CTRL-C), in which case the current progress will be saved to a "cache" (json file), and it will pick up where it left off the next time it is run.

Example output:

![sequential_term](https://github.com/user-attachments/assets/f2e3f620-674e-4f28-a648-74892fba758f)

Any interest in upstreaming it here? It currently lives on my fork: https://github.com/tbidne/clc-stackage/tree/sequential?tab=readme-ov-file#sequential-builds