### PR TITLE
Improve test output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,12 @@ on:
     branches:
       - master
 
+  schedule:
+    # Every day at 00:00 UTC.
+    #
+    # https://crontab.guru
+    - cron: '0 0 * * *'
+
   workflow_dispatch:
 jobs:
   cabal:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: haskell-actions/setup@v2
         with:
-          ghc-version: "9.10.1"
+          ghc-version: "9.10.2"
       - name: Configure
         run: |
           cabal configure --enable-tests --ghc-options -Werror

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,26 +34,25 @@ jobs:
         id: unit
         run: cabal test unit
 
-      - name: Print unit failures
-        if: ${{ failure() && steps.unit.conclusion == 'failure' }}
-        run: |
-          cd test/unit/goldens
-
-          for f in $(ls); do
-            echo "$f"
-            cat "$f"
-          done
-
       - name: Functional Tests
         id: functional
-        run: cabal test functional
+        shell: bash
+        run: NO_CLEANUP=1 cabal test functional
 
       - name: Print functional failures
         if: ${{ failure() && steps.functional.conclusion == 'failure' }}
+        shell: bash
         run: |
-          cd test/functional/goldens
 
-          for f in $(ls); do
-            echo "$f"
-            cat "$f"
-          done
+          if [[ ! -d output/logs ]]; then
+            echo "*** No output ***"
+          else
+            cd output/logs
+
+            for dir in */; do
+              echo "*** $d stdout ***"
+              cat "$dir/stdout.log"
+              echo "*** $d stderr ***"
+              cat "$dir/stderr.log"
+            done
+          fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
         os:
           - "macos-latest"
           - "ubuntu-latest"
+          - "windows-latest"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # `clc-stackage`
 
+[![ci](https://github.com/haskell/clc-stackage/actions/workflows/ci.yaml/badge.svg)](https://github.com/haskell/clc-stackage/actions/workflows/ci.yaml)
+
 ## How to?
 
 This is a meta-package to facilitate impact assessment for [CLC proposals](https://github.com/haskell/core-libraries-committee).

--- a/clc-stackage.cabal
+++ b/clc-stackage.cabal
@@ -128,6 +128,18 @@ executable clc-stackage
   hs-source-dirs: ./app
   ghc-options:    -threaded -with-rtsopts=-N
 
+library test-utils
+  import:          common-lang
+  exposed-modules:
+    Test.Utils
+
+  build-depends:
+    , base
+    , tasty         >=1.1.0.3  && <1.6
+    , tasty-golden  ^>=2.3.1.1
+
+  hs-source-dirs:  test/utils
+
 test-suite unit
   import:         common-lang
   type:           exitcode-stdio-1.0
@@ -143,9 +155,10 @@ test-suite unit
     , containers
     , filepath
     , runner
-    , tasty         >=1.1.0.3  && <1.6
-    , tasty-golden  ^>=2.3.1.1
+    , tasty
+    , tasty-golden
     , tasty-hunit   >=0.9      && <0.11
+    , test-utils
     , time
     , utils
 
@@ -164,6 +177,7 @@ test-suite functional
     , env-guard     ^>=0.2
     , filepath
     , runner
+    , test-utils
     , tasty
     , tasty-golden
     , text

--- a/src/runner/CLC/Stackage/Runner/Env.hs
+++ b/src/runner/CLC/Stackage/Runner/Env.hs
@@ -45,19 +45,19 @@ import CLC.Stackage.Utils.Logging qualified as Logging
 import CLC.Stackage.Utils.Paths qualified as Paths
 import Control.Exception (throwIO)
 import Control.Monad (unless)
-import Data.Bool (Bool (True, False), not)
+import Data.Bool (Bool (False, True), not)
 import Data.Foldable (Foldable (foldl'))
 import Data.IORef (newIORef, readIORef)
 import Data.List.NonEmpty (NonEmpty ((:|)))
-import Data.Maybe (Maybe (Just, Nothing), maybe, fromMaybe)
+import Data.Maybe (Maybe (Just, Nothing), fromMaybe, maybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text qualified as T
 import Data.Time (LocalTime)
-import Prelude (IO, (.), ($), pure, show, mconcat, (<>), (<$>), (++))
 import System.Console.Pretty (supportsPretty)
 import System.Directory.OsPath qualified as Dir
 import System.Exit (ExitCode (ExitSuccess))
+import Prelude (IO, mconcat, pure, show, ($), (++), (.), (<$>), (<>))
 
 -- | Args used for building all packages.
 data RunnerEnv = MkRunnerEnv

--- a/test/unit/Unit/CLC/Stackage/Runner/Report.hs
+++ b/test/unit/Unit/CLC/Stackage/Runner/Report.hs
@@ -63,7 +63,7 @@ testMkReport = testCase "Creates a report" $ do
         }
 
 testResultJsonEncode :: TestTree
-testResultJsonEncode = goldenVsFile desc goldenFilePath actualFilePath $ do
+testResultJsonEncode = goldenDiffCustom desc goldenFilePath actualFilePath $ do
   let json = JSON.encodePretty results <> "\n"
 
   IO.writeBinaryFile actualOsPath json
@@ -82,7 +82,7 @@ testResultJsonEncode = goldenVsFile desc goldenFilePath actualFilePath $ do
         }
 
 testReportJsonEncode :: TestTree
-testReportJsonEncode = goldenVsFile desc goldenFilePath actualFilePath $ do
+testReportJsonEncode = goldenDiffCustom desc goldenFilePath actualFilePath $ do
   let json = JSON.encodePretty report <> "\n"
 
   IO.writeBinaryFile actualOsPath json

--- a/test/unit/Unit/Prelude.hs
+++ b/test/unit/Unit/Prelude.hs
@@ -38,8 +38,8 @@ import Data.List.NonEmpty qualified as NE
 import Data.Set qualified as Set
 import Data.Time.LocalTime (LocalTime (LocalTime), midday)
 import Test.Tasty as X (TestTree, testGroup)
-import Test.Tasty.Golden as X (goldenVsFile)
 import Test.Tasty.HUnit as X (assertFailure, testCase, (@=?))
+import Test.Utils as X (goldenDiffCustom)
 
 mkRunnerEnv :: IO RunnerEnv
 mkRunnerEnv = do

--- a/test/utils/Test/Utils.hs
+++ b/test/utils/Test/Utils.hs
@@ -1,0 +1,27 @@
+module Test.Utils
+  ( goldenDiffCustom,
+  )
+where
+
+import Test.Tasty (TestName, TestTree)
+import Test.Tasty.Golden (goldenVsFileDiff)
+
+-- | We use a custom diff as this will print the actual diff to stdout,
+-- whereas ordinary goldenVsFile will merely print something like
+-- 'files are different'. The former is especially useful when we do not have
+-- easy access to the diff files e.g. CI.
+goldenDiffCustom :: TestName -> FilePath -> FilePath -> IO () -> TestTree
+goldenDiffCustom x = goldenVsFileDiff x diffArgs
+  where
+    -- Apparently, the 'diff' program exists for windows and unix on CI. Thus
+    -- the arguments ["diff", "-u" "--color=always", ref, new] also seem fine.
+    -- Nevertheless, we use git as it is possibly more portable.
+    diffArgs ref new =
+      [ "git",
+        "diff",
+        "--exit-code",
+        "--color=always",
+        "--no-index",
+        ref,
+        new
+      ]


### PR DESCRIPTION
@Bodigrim There are a few things here.

1. You fixed the `-Wunused-imports` error. Thanks for that.

2. CI was _probably_ failing due to using ghc `9.10.1`, whereas the [snapshot](https://www.stackage.org/nightly-2025-05-23) is `9.10.2`. This currently matters because we write the entire snapshot as `cabal.project.local` constraints, to ensure the same transitive dependencies every time. But this will cause a failure for different ghc minor versions because e.g. base will not have the same version.

    For this reason, I think some non-reinstallable packages like `base` should be added to `excluded_pkgs.json`. They will be built anyway, and this way we don't enforce exact bounds in the constraints. Alternatively, we could hardcode logic to avoid writing `base`, etc. in the [haskell itself](https://github.com/haskell/clc-stackage/blob/master/src/builder/CLC/Stackage/Builder/Writer.hs#L30).
    
    However, we cannot currently see this error because...
    
3. The stackage endpoint has stopped returning json. This only happened a few days ago, after the original CI error. That is:

    ```
    $ curl -H "Accept: application/json" -L https://stackage.org/nightly-2025-05-23
    <raw_html>
    ```

    This is something I have noticed in the past i.e. the endpoint does not reliably return json, in the sense that _some_ endpoints will always return html, whereas others will return json with the right headers. I _thought_ that once you found an endpoint that returned json, it always would, but apparently that is mistaken. Even the previously working snapshot, `nightly-2024-03-26`, is currently returning html.
    
    So this is the top priority, since this will block everything else from working, and is in fact a real error.
    
    There are quite a few [related issues](https://github.com/commercialhaskell/stackage-server/issues/348), though I am unsure of their exact relevance. It would be nice if this could be "fixed" from the stackage side, but if not, perhaps we need to switch to parsing something else e.g. https://github.com/commercialhaskell/stackage-snapshots/blob/master/nightly/2025/5/23.yaml or `cabal.config` (though note that currently `https://stackage.org/nightly-2025-05-23/cabal.config` is returning a gateway error).
    
This PR does not currently fix the stackage error, though it does improve the error output, and may fix the original error.