### PR TITLE
Exclude gtk-scaling-image

### DIFF
--- a/excluded_pkgs.jsonc
+++ b/excluded_pkgs.jsonc
@@ -160,6 +160,7 @@
     "gopher-proxy",
     "group-by-date",
     "gtk",
+    "gtk-scaling-image",
     "gtk-sni-tray",
     "gtk-strut",
     "gtk2hs-buildtools",


### PR DESCRIPTION
Of course, as soon as I notice that CI is fixed, nightly pulls in a new package that needs to be excluded, and fails.

At least this indicates the CI job is helpful.