### PR TITLE
Exclude deriving-trans

### DIFF
--- a/package_index.jsonc
+++ b/package_index.jsonc
@@ -56,6 +56,15 @@
       "cutter",
       "dbcleaner",
       "dbus-menu", // gtk-3
+      // Nightly deriving-trans (0.11.0.0) is only compatible with the
+      // latest mtl (2.3.2) at the _minor_ level i.e. lower versions fail.
+      // This is a problem if we want to allow usage with multiple GHC minors,
+      // as mtl is a boot package, hence we do not pin deriving-trans.
+      //
+      // Once boot packages are re-installable with ghc, we can remove mtl and
+      // the rest from the 'unpinned' key here, and then we be able to allow
+      // deriving-trans again.
+      "deriving-trans",
       "diagrams-svg",
       "discount",
       "dl-fedora",


### PR DESCRIPTION
The `deriving-trans-0.11.0.0` package was just added to the latest `nightly`. Unfortunately, this package is only compatible with the latest `mtl-2.3.2`, not any minor versions below it. This is fine for stackage and if your GHC is `9.12.4`, but it's not fine for older GHCs (e.g. CI's `9.12.2`), which is a problem since we try to be compatible with multiple minors.

Since:

  1. `deriving-trans` doesn't seem to have any [reverse deps](https://packdeps.haskellers.com/reverse).
  2. IMO it's not feasible to try to handle packages that do not work across boot package minor ranges.

It seems best to exclude `deriving-trans` for now.